### PR TITLE
Add Share To Support to Images

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,8 +72,15 @@
         <activity
             android:name=".CropActivity"
             android:launchMode="singleTask"
-            android:label=""
+            android:label="@string/app_name"
             android:screenOrientation="portrait">
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".InputActivity" />

--- a/app/src/main/java/com/transcendentlabs/xcerpt/CropActivity.java
+++ b/app/src/main/java/com/transcendentlabs/xcerpt/CropActivity.java
@@ -11,12 +11,10 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.MediaStore;
-import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.Window;
 import android.widget.Toast;
 
 import com.edmodo.cropper.CropImageView;
@@ -27,7 +25,6 @@ import java.util.ArrayList;
 import static com.transcendentlabs.xcerpt.Util.EXCERPT;
 import static com.transcendentlabs.xcerpt.Util.getStorageDirectory;
 import static com.transcendentlabs.xcerpt.Util.initOcrIfNecessary;
-import static com.transcendentlabs.xcerpt.Util.setActionBarColour;
 
 public class CropActivity extends BaseActivity {
 
@@ -55,10 +52,18 @@ public class CropActivity extends BaseActivity {
     private boolean initializeCropView() {
         cropImageView = (CropImageView) findViewById(R.id.CropImageView);
         cropImageView.setGuidelines(0);
-        Bundle extras = getIntent().getExtras();
-        Uri uri = Uri.parse(extras.getString(InputActivity.IMAGE));
+        Intent receivedIntent = getIntent();
+        String action = receivedIntent.getAction();
+        Bundle extras = receivedIntent.getExtras();
+        Uri uri;
+        if(Intent.ACTION_SEND.equals(action)) {
+            uri = extras.getParcelable(Intent.EXTRA_STREAM);
+        } else {
+            uri = Uri.parse(extras.getString(InputActivity.IMAGE));
+        }
         try {
             Bitmap img = MediaStore.Images.Media.getBitmap(this.getContentResolver(), uri);
+
             if(img == null) {
                 finish();
                 return false;

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0-rc2'
+        classpath 'com.android.tools.build:gradle:2.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jul 19 04:02:27 EDT 2015
+#Sat Apr 16 13:06:01 MST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/tess-two/build.gradle
+++ b/tess-two/build.gradle
@@ -2,9 +2,6 @@ buildscript {
     repositories {
         jcenter()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0-rc2'
-    }
 }
 
 apply plugin: 'com.android.library'


### PR DESCRIPTION
Closes #7 

This was fairly straightforward, I was able to leverage what you already had for fetching the image from a uri. I only needed to pull the uri from the intent and pass that along. It seems to work well for me, and the application seems to be stable.

![image](https://cloud.githubusercontent.com/assets/137686/14583817/6ef415e6-03e2-11e6-94aa-d9d2e5b84920.png)
You may want to change the description from "Xcerpt" to "Hightlight Screenshot" or something else.

You'll see below that I also needed to upgrade the gradle wrapper so that I could build the project.